### PR TITLE
chore(release): 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 Semantic Versioning.
 
 ---
+## 1.0.2 — 2025-09-10
+- Add “Refresh All Sizes” to command palette.
+- Watch external changes to keep sizes fresh (light debounce)
+- Docs: clarify deep-scan command and settings
 
 ## 1.0.1 — 2025-08-27
 - Marketplace: add Visualization category

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Tiny, fast badges in the VS Code Explorer showing file sizes. Hover to see exact
 ![Demo](https://github.com/bdoole1/explorer-file-sizes/blob/main/images/demo.gif?raw=true)
 > Tip: Prefer **Subtle** for clean Explorer UI—tooltips without extra badges.
 
+> **What’s new in 1.0.2**
+> - **Refresh All Sizes** command (clear cache + refresh decorations).
+> - **External change watcher** to keep sizes fresh when files change outside VS Code.
+> - **Folder Badge Mode** is now set to showing folder sizes by default.
+
 ---
 
 ## Features
@@ -34,11 +39,11 @@ Tiny, fast badges in the VS Code Explorer showing file sizes. Hover to see exact
   - `nocase` on Windows
   - Matches both **absolute** and **workspace-relative** paths
 - Examples:
-  - Ignore all `node_modules`:  
+  - Ignore all `node_modules`:
     `**/node_modules/**`
-  - Ignore generated assets:  
+  - Ignore generated assets:
     `**/dist/**`, `**/build/**`, `**/.next/**`, `**/target/**`
-  - Ignore logs/temp:  
+  - Ignore logs/temp:
     `**/*.log`, `**/tmp/**`, `**/.cache/**`
 
 > Tune this list per project for faster, more accurate folder sizes.
@@ -52,6 +57,15 @@ Tiny, fast badges in the VS Code Explorer showing file sizes. Hover to see exact
 - Reads metadata via the VS Code **FileSystem** API—no external binaries, no telemetry.
 
 ---
+## Commands
+
+- **Explorer File Sizes: Show Folder Size**
+  Right-click a folder in Explorer → *Show Folder Size* (deep scan with progress).
+
+- **Explorer File Sizes: Refresh All Sizes**
+  Command Palette → *Refresh All Sizes* to clear the cache and refresh all decorations immediately.
+
+---
 
 ### Installation
 
@@ -60,7 +74,7 @@ Tiny, fast badges in the VS Code Explorer showing file sizes. Hover to see exact
 **From Marketplace (recommended)**
 1. Open the **Extensions** view (`Ctrl/Cmd+Shift+X`).
 2. Search **Explorer File Sizes**.
-3. Click **Install**.  
+3. Click **Install**.
    > For Remote-SSH/WSL/Containers, use **Install in…** to target the remote.
 
 **Install via CLI**
@@ -122,6 +136,9 @@ code-insiders --install-extension ./explorer-file-sizes-<version>.vsix
 - VS Code shows **one** decoration per item; other providers may mask this extension’s badge/tooltip on that item.
 - Budgets (time/entry count) keep the UI responsive; folder tooltips show `~` when that happens.
 - Use the Explorer context menu for a guaranteed, deeper folder size.
+
+## Privacy
+This extension sends **no telemetry** and makes **no network requests**. All size calculations happen locally.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "explorer-file-sizes",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "explorer-file-sizes",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "minimatch": "^9.0.3"

--- a/package.json
+++ b/package.json
@@ -2,16 +2,44 @@
   "name": "explorer-file-sizes",
   "displayName": "Explorer File Sizes",
   "description": "Tiny, fast file size badges in the VS Code Explorer with tooltips and optional folder sizes.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publisher": "BrianDooley",
-  "engines": { "vscode": "^1.90.0" },
-  "categories": ["Other", "Visualization"],
-  "keywords": ["explorer", "file size", "file sizes", "decorations", "badge", "tooltip","explorer",
-    "file-size", "folder-size", "sizes", "filesize", "badges", "tooltip", "decorations", "file-decorations",
-    "explorer-decorations", "hover", "status-bar", "disk-usage", "resource-usage", "performance", "glob",
-    "exclude", "minimatch"
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Other",
+    "Visualization"
   ],
-  "activationEvents": ["onStartupFinished"],
+  "keywords": [
+    "explorer",
+    "file size",
+    "file sizes",
+    "decorations",
+    "badge",
+    "tooltip",
+    "explorer",
+    "file-size",
+    "folder-size",
+    "sizes",
+    "filesize",
+    "badges",
+    "tooltip",
+    "decorations",
+    "file-decorations",
+    "explorer-decorations",
+    "hover",
+    "status-bar",
+    "disk-usage",
+    "resource-usage",
+    "performance",
+    "glob",
+    "exclude",
+    "minimatch"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./dist/extension.js",
   "icon": "images/icon.png",
   "files": [
@@ -22,8 +50,13 @@
     "LICENSE",
     "package.json"
   ],
-  "repository": { "type": "git", "url": "https://github.com/bdoole1/explorer-file-sizes.git" },
-  "bugs": { "url": "https://github.com/bdoole1/explorer-file-sizes/issues" },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bdoole1/explorer-file-sizes.git"
+  },
+  "bugs": {
+    "url": "https://github.com/bdoole1/explorer-file-sizes/issues"
+  },
   "homepage": "https://github.com/bdoole1/explorer-file-sizes#readme",
   "license": "MIT",
   "contributes": {
@@ -32,7 +65,11 @@
       "properties": {
         "explorerFileSizes.badgeMode": {
           "type": "string",
-          "enum": ["full", "subtle", "off"],
+          "enum": [
+            "full",
+            "subtle",
+            "off"
+          ],
           "default": "full",
           "description": "How badges render in the Explorer:\nfull = 2-char size (e.g. 1M);\nsubtle = tooltip only (no badge);\noff = no decorations (status bar still shows active file size)."
         },
@@ -43,20 +80,34 @@
         },
         "explorerFileSizes.folderHoverIndicator": {
           "type": "string",
-          "enum": ["calculating", "off"],
+          "enum": [
+            "calculating",
+            "off"
+          ],
           "default": "calculating",
           "description": "Folder hover hotspot. 'calculating' shows ⏳ only while 'off' disables folder tooltips."
         },
         "explorerFileSizes.excludeGlobs": {
           "type": "array",
-          "default": ["**/node_modules/**", "**/.git/**", "**/dist/**", "**/build/**"],
-          "items": { "type": "string" },
+          "default": [
+            "**/node_modules/**",
+            "**/.git/**",
+            "**/dist/**",
+            "**/build/**"
+          ],
+          "items": {
+            "type": "string"
+          },
           "description": "Globs to exclude when computing folder sizes."
         },
         "explorerFileSizes.folderBadgeMode": {
           "type": "string",
-          "enum": ["off", "calculating", "size"],
-          "default": "calculating",
+          "enum": [
+            "off",
+            "calculating",
+            "size"
+          ],
+          "default": "size",
           "description": "Folder badges:\n'off' = none,\n'calculating' = show ⏳ while computing,\n'size' = show 2-char size after computed (may conflict with other badges)."
         }
       }
@@ -64,7 +115,12 @@
     "commands": [
       {
         "command": "explorerFileSizes.showFolderSize",
-        "title": "Explorer File Sizes: Show Folder Size",
+        "title": "Show Folder Size",
+        "category": "Explorer File Sizes"
+      },
+      {
+        "command": "explorerFileSizes.refreshAll",
+        "title": "Refresh All Sizes",
         "category": "Explorer File Sizes"
       }
     ],


### PR DESCRIPTION
Adds a manual refresh command and keeps sizes fresh when files change outside VS Code (e.g. scp/rsync/git checkout/build outputs).

• New command: explorerFileSizes.refreshAll
  - Clears the in-memory size cache
  - Triggers a decorations refresh immediately (badges/tooltips redraw)
  - Updates the status bar size for the active file
  - Exposed in the Command Palette

• External change watcher (debounced)
  - FileSystemWatcher per workspace folder (RelativePattern **/*)
  - onDidCreate/onDidChange/onDidDelete → invalidate the touched file and its ancestor folders, then fire decoration updates for those URIs
  - Debounced to avoid event storms during large copies
  - Improves accuracy for long-running/partial external writes

• Docs
  - README: add “What’s new in 1.0.2”, Commands section, install notes cleanup; clarify deep-scan context menu

Performance/UX:
- No deep rescans are triggered automatically; we only invalidate cache and let the provider recompute on demand (visible items/hovered nodes).
- Folder scan budgets remain unchanged; use the context menu “Show Folder Size” for a deeper scan with progress.

Testing:
- Local: truncate/grow/shrink files; tooltips and folder totals update
- External: scp/rsync copy then cancel mid-transfer; size reflects last written bytes
- Remote: Remote-SSH/WSL/Containers basic sanity passes